### PR TITLE
+ update from deprecated template provider

### DIFF
--- a/cluster/multi-ad/compute.tf
+++ b/cluster/multi-ad/compute.tf
@@ -22,7 +22,7 @@ resource "oci_core_instance" "BastionHost" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init_bastion.rendered
+    user_data = data.cloudinit_config.cloud_init_bastion.rendered
   }
 
   source_details {
@@ -60,7 +60,7 @@ resource "oci_core_instance" "ESMasterNode1" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -99,7 +99,7 @@ resource "oci_core_instance" "ESMasterNode2" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -138,7 +138,7 @@ resource "oci_core_instance" "ESMasterNode3" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -177,7 +177,7 @@ resource "oci_core_instance" "ESDataNode1" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -216,7 +216,7 @@ resource "oci_core_instance" "ESDataNode2" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -255,7 +255,7 @@ resource "oci_core_instance" "ESDataNode3" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -294,7 +294,7 @@ resource "oci_core_instance" "ESDataNode4" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {

--- a/cluster/multi-ad/datasources.tf
+++ b/cluster/multi-ad/datasources.tf
@@ -163,38 +163,24 @@ data "oci_identity_region_subscriptions" "home_region_subscriptions" {
 
 # This Terraform script provisions a compute instance
 
-data "template_file" "key_script" {
-  template = file("./scripts/sshkey.tpl")
-  vars = {
-    ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh
-  }
-}
-
-data "template_cloudinit_config" "cloud_init" {
+data "cloudinit_config" "cloud_init" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "ainit.sh"
     content_type = "text/x-shellscript"
-    content      = data.template_file.key_script.rendered
+    content      = templatefile("${path.module}/scripts/sshkey.tpl", { ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh })
   }
 }
 
-data "template_file" "key_script_bastion" {
-  template = file("./scripts/BastionBootStrap.sh")
-  vars = {
-    ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh
-  }
-}
-
-data "template_cloudinit_config" "cloud_init_bastion" {
+data "cloudinit_config" "cloud_init_bastion" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "ainit.sh"
     content_type = "text/x-shellscript"
-    content      = data.template_file.key_script_bastion.rendered
+    content      = templatefile("${path.module}/scripts/BastionBootStrap.sh", { ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh })
   }
 }

--- a/cluster/multi-ad/remote.tf
+++ b/cluster/multi-ad/remote.tf
@@ -1,29 +1,6 @@
 ## Copyright (c) 2022, Oracle and/or its affiliates. 
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
-data "template_file" "setup_esbootstrap" {
-  depends_on = [oci_core_instance.ESMasterNode1, oci_core_instance.ESMasterNode2, oci_core_instance.ESMasterNode3, oci_core_instance.ESDataNode1, oci_core_instance.ESDataNode2, oci_core_instance.ESDataNode3, oci_core_instance.ESDataNode4]
-  
-  template = file(var.ESBootStrap)
-
-  vars = {
-    elasticsearch_download_url      = var.elasticsearch_download_url
-    kibana_download_url             = var.kibana_download_url
-    elasticsearch_download_version  = var.elasticsearch_download_version
-    kibana_download_version         = var.kibana_download_version
-    ESDataPort                      = var.ESDataPort
-    ESDataPort2                     = var.ESDataPort2
-    KibanaPort                      = var.KibanaPort
-    esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
-    esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
-    esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
-    esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address 
-    esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
-    esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
-    esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
-  }
-}
-
 resource "null_resource" "ESMasterNode1_BootStrap" {
   depends_on = [oci_core_instance.BastionHost, oci_core_instance.ESMasterNode1, oci_core_instance.ESMasterNode2, oci_core_instance.ESMasterNode3, oci_core_instance.ESDataNode1, oci_core_instance.ESDataNode2, oci_core_instance.ESDataNode3, oci_core_instance.ESDataNode4]
 
@@ -42,8 +19,23 @@ resource "null_resource" "ESMasterNode1_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -84,8 +76,23 @@ resource "null_resource" "ESMasterNode2_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -126,8 +133,23 @@ resource "null_resource" "ESMasterNode3_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -168,8 +190,23 @@ resource "null_resource" "ESDataNode1_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -210,8 +247,23 @@ resource "null_resource" "ESDataNode2_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -252,8 +304,23 @@ resource "null_resource" "ESDataNode3_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -294,8 +361,23 @@ resource "null_resource" "ESDataNode4_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      esdatanode4_private_ip          = data.oci_core_vnic.ESDataNode4Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {

--- a/cluster/single-ad/compute.tf
+++ b/cluster/single-ad/compute.tf
@@ -24,7 +24,7 @@ resource "oci_core_instance" "BastionHost" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init_bastion.rendered
+    user_data = data.cloudinit_config.cloud_init_bastion.rendered
   }
 
   source_details {
@@ -61,7 +61,7 @@ resource "oci_core_instance" "ESMasterNode1" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -99,7 +99,7 @@ resource "oci_core_instance" "ESMasterNode2" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -137,7 +137,7 @@ resource "oci_core_instance" "ESMasterNode3" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -175,7 +175,7 @@ resource "oci_core_instance" "ESDataNode1" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -215,7 +215,7 @@ resource "oci_core_instance" "ESDataNode2" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {
@@ -255,7 +255,7 @@ resource "oci_core_instance" "ESDataNode3" {
 
   metadata = {
     ssh_authorized_keys = var.ssh_public_key
-    user_data = data.template_cloudinit_config.cloud_init.rendered
+    user_data = data.cloudinit_config.cloud_init.rendered
   }
 
   source_details {

--- a/cluster/single-ad/datasources.tf
+++ b/cluster/single-ad/datasources.tf
@@ -158,39 +158,25 @@ data "oci_identity_region_subscriptions" "home_region_subscriptions" {
 
 # This Terraform script provisions a compute instance
 
-data "template_file" "key_script" {
-  template = file("./scripts/sshkey.tpl")
-  vars = {
-    ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh
-  }
-}
-
-data "template_cloudinit_config" "cloud_init" {
+data "cloudinit_config" "cloud_init" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "ainit.sh"
     content_type = "text/x-shellscript"
-    content      = data.template_file.key_script.rendered
+    content      = templatefile("${path.module}/scripts/sshkey.tpl", { ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh })
   }
 }
 
 
-data "template_file" "key_script_bastion" {
-  template = file("./scripts/BastionBootStrap.sh")
-  vars = {
-    ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh
-  }
-}
-
-data "template_cloudinit_config" "cloud_init_bastion" {
+data "cloudinit_config" "cloud_init_bastion" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "ainit.sh"
     content_type = "text/x-shellscript"
-    content      = data.template_file.key_script_bastion.rendered
+    content      = templatefile("${path.module}/scripts/BastionBootStrap.sh", { ssh_public_key = tls_private_key.public_private_key_pair.public_key_openssh })
   }
 }

--- a/cluster/single-ad/remote.tf
+++ b/cluster/single-ad/remote.tf
@@ -1,29 +1,6 @@
 ## Copyright (c) 2022, Oracle and/or its affiliates. 
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
-
-data "template_file" "setup_esbootstrap" {
-  depends_on = [oci_core_instance.ESMasterNode1, oci_core_instance.ESMasterNode2, oci_core_instance.ESMasterNode3, oci_core_instance.ESDataNode1, oci_core_instance.ESDataNode2, oci_core_instance.ESDataNode3]
-
-  template = file(var.ESBootStrap)
-
-  vars = {
-    elasticsearch_download_url      = var.elasticsearch_download_url
-    kibana_download_url             = var.kibana_download_url
-    elasticsearch_download_version  = var.elasticsearch_download_version
-    kibana_download_version         = var.kibana_download_version
-    ESDataPort                      = var.ESDataPort
-    ESDataPort2                     = var.ESDataPort2
-    KibanaPort                      = var.KibanaPort
-    esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
-    esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
-    esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
-    esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address 
-    esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
-    esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
-  }
-}
-
 resource "null_resource" "ESMasterNode1_BootStrap" {
   depends_on = [oci_core_instance.BastionHost, oci_core_instance.ESMasterNode1, oci_core_instance.ESMasterNode2, oci_core_instance.ESMasterNode3, oci_core_instance.ESDataNode1, oci_core_instance.ESDataNode2, oci_core_instance.ESDataNode3]
 
@@ -42,8 +19,22 @@ resource "null_resource" "ESMasterNode1_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+    })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -84,8 +75,22 @@ resource "null_resource" "ESMasterNode2_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -126,8 +131,22 @@ resource "null_resource" "ESMasterNode3_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -168,8 +187,22 @@ resource "null_resource" "ESDataNode1_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -210,8 +243,22 @@ resource "null_resource" "ESDataNode2_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {
@@ -252,8 +299,22 @@ resource "null_resource" "ESDataNode3_BootStrap" {
       bastion_private_key = tls_private_key.public_private_key_pair.private_key_pem
     }
 
-    content     = data.template_file.setup_esbootstrap.rendered
-    destination = "~/esbootstrap.sh"
+    content     = templatefile("${path.module}/${var.ESBootStrap}", {
+      elasticsearch_download_url      = var.elasticsearch_download_url
+      kibana_download_url             = var.kibana_download_url
+      elasticsearch_download_version  = var.elasticsearch_download_version
+      kibana_download_version         = var.kibana_download_version
+      ESDataPort                      = var.ESDataPort
+      ESDataPort2                     = var.ESDataPort2
+      KibanaPort                      = var.KibanaPort
+      esmasternode1_private_ip        = data.oci_core_vnic.ESMasterNode1Vnic.private_ip_address
+      esmasternode2_private_ip        = data.oci_core_vnic.ESMasterNode2Vnic.private_ip_address
+      esmasternode3_private_ip        = data.oci_core_vnic.ESMasterNode3Vnic.private_ip_address
+      esdatanode1_private_ip          = data.oci_core_vnic.ESDataNode1Vnic.private_ip_address
+      esdatanode2_private_ip          = data.oci_core_vnic.ESDataNode2Vnic.private_ip_address
+      esdatanode3_private_ip          = data.oci_core_vnic.ESDataNode3Vnic.private_ip_address
+      })
+    destination = "/home/opc/esbootstrap.sh"
   }
   provisioner "remote-exec" {
     connection {


### PR DESCRIPTION
Hi,

the TF can not be run on Apple Silicon, because the 'template' provider is not available for aarm processor.

I have created a simple upgrade migrating from 'template' provider to templatefile function and also upgraded cloudinit for cluster variants. Please consider these ideas for adding Apple Silicon support.

I have successfully tested both single-ad and multi-ad on my OCI cluster.

Thank you.